### PR TITLE
docs:fix the link to AWS CLI install page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository includes the following samples.
 
 * [Node.js](https://nodejs.org/en/download/)
   * v16 or higher is recommended
-* [AWS CLI](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/getting-started-install.html)
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)  ([View this page in Japanese](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/getting-started-install.html))
   * v2 is recommended
 * Valid unassigned [Unity Build Server License](https://unity.com/products/unity-build-server)
   * Free trial licenses are recommended in PoC


### PR DESCRIPTION
The AWS CLI install page was redirecting to the Japanese version of the page by default .I added a link to the English version of the page and also provided an option to go to the Japanese version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
