### PR TITLE
Set a removal policy to ENI

### DIFF
--- a/cdk/lib/unity-license-server-stack.ts
+++ b/cdk/lib/unity-license-server-stack.ts
@@ -56,10 +56,7 @@ export class UnityLicenseServerStack extends cdk.Stack {
         },
       ],
     });
-    eni.applyRemovalPolicy(RemovalPolicy.RETAIN, {
-      applyToUpdateReplacePolicy: true,
-      default: cdk.RemovalPolicy.RETAIN,
-    });
+    eni.applyRemovalPolicy(RemovalPolicy.RETAIN);
 
     const bucket = new s3.Bucket(this, 'Bucket', {
       removalPolicy: RemovalPolicy.DESTROY,

--- a/cdk/lib/unity-license-server-stack.ts
+++ b/cdk/lib/unity-license-server-stack.ts
@@ -56,6 +56,10 @@ export class UnityLicenseServerStack extends cdk.Stack {
         },
       ],
     });
+    eni.applyRemovalPolicy(RemovalPolicy.RETAIN, {
+      applyToUpdateReplacePolicy: true,
+      default: cdk.RemovalPolicy.RETAIN,
+    });
 
     const bucket = new s3.Bucket(this, 'Bucket', {
       removalPolicy: RemovalPolicy.DESTROY,


### PR DESCRIPTION
*Issue #, if available:*

None.

Issue: The ENI was replaced with a new one when I changed VPC settings, and my Unity license doesn't work after that.

*Description of changes:*

This pull request sets a removal polity to ENI to avoid the accidental deletion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
