### PR TITLE
Change base image to Amazon Linux 2023

### DIFF
--- a/cdk/lib/unity-license-server-ami-stack.ts
+++ b/cdk/lib/unity-license-server-ami-stack.ts
@@ -28,7 +28,7 @@ export class UnityLicenseServerAmiStack extends cdk.Stack {
     const launchTemplate = new ec2.LaunchTemplate(this, 'LaunchTemplate', {
       instanceType: new ec2.InstanceType('t3.small'),
       machineImage: new ec2.AmazonLinuxImage({
-        generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
+        generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2023,
       }),
       role,
       blockDevices: [

--- a/cdk/test/__snapshots__/unity-build-server.test.ts.snap
+++ b/cdk/test/__snapshots__/unity-build-server.test.ts.snap
@@ -27,8 +27,8 @@ exports[`UnityLicenseServerAmiStack test 1`] = `
       "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+    "SsmParameterValueawsserviceamiamazonlinuxlatestal2023amikernel61x8664C96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
     },
   },
@@ -80,7 +80,7 @@ exports[`UnityLicenseServerAmiStack test 1`] = `
             },
           },
           "ImageId": {
-            "Ref": "SsmParameterValueawsserviceamiamazonlinuxlatestamzn2amihvmx8664gp2C96584B6F00A464EAD1953AFF4B05118Parameter",
+            "Ref": "SsmParameterValueawsserviceamiamazonlinuxlatestal2023amikernel61x8664C96584B6F00A464EAD1953AFF4B05118Parameter",
           },
           "InstanceType": "t3.small",
           "NetworkInterfaces": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AL2 has an older version of libc which is no longer compatible with the newer versions of Unity license server.

This change updates the base image to use Amazon Linux 2023 which does work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
