### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     - main
   workflow_dispatch:
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   Build-and-Test-CDK:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_snapshot.yml
+++ b/.github/workflows/update_snapshot.yml
@@ -3,6 +3,9 @@ name: Update snapshot
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.